### PR TITLE
feat: support external source-maps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -893,8 +893,7 @@
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-      "dev": true
+      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -3077,7 +3076,6 @@
       "version": "0.5.19",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
       "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
-      "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "find-up": "^5.0.0",
     "glob": "^7.1.6",
     "promise-assist": "^1.3.0",
+    "source-map-support": "^0.5.19",
     "style-loader": "^2.0.0",
     "webpack-dev-middleware": "^4.0.2"
   },

--- a/static/mocha-setup.js
+++ b/static/mocha-setup.js
@@ -2,6 +2,9 @@ import mochaModule from 'mocha/mocha.js';
 // styles needed by the html reporter
 import '!style-loader!css-loader!mocha/mocha.css';
 
+import 'source-map-support/browser-source-map-support';
+sourceMapSupport.install();
+
 // mocha@8.2.1 changed into umd bundle
 const mocha = window.mocha || mochaModule;
 

--- a/test/cli.spec.ts
+++ b/test/cli.spec.ts
@@ -57,6 +57,18 @@ describe('mocha-pup', function () {
     expect(status).to.equal(0);
   });
 
+  it('shows source locations on errors for external source maps', () => {
+    const { stdout, status } = runMochaPup({
+      args: ['./fails.ts'],
+      fixture: 'with-config',
+    });
+
+    expect(stdout).to.include('Found 1 test files');
+    expect(stdout).to.include('1 failing');
+    expect(stdout).to.include('fails.ts:8:11');
+    expect(status).to.equal(1);
+  });
+
   it('allows bundling using custom webpack configuration', () => {
     const { stdout, status } = runMochaPup({
       args: ['./typescript-file.ts', '-c', './my.config.js'],

--- a/test/fixtures/with-config/fails.ts
+++ b/test/fixtures/with-config/fails.ts
@@ -1,0 +1,10 @@
+interface SomeInterface {
+  x: number;
+  y: number;
+}
+
+describe('suite', () => {
+  it('fails with source-maps', () => {
+    throw new Error('failure from line 8');
+  });
+});

--- a/test/fixtures/with-config/webpack.config.js
+++ b/test/fixtures/with-config/webpack.config.js
@@ -1,5 +1,6 @@
 /** @type {import('webpack').Configuration} */
 module.exports = {
+  devtool: 'source-map',
   module: {
     rules: [
       {


### PR DESCRIPTION
errors are remapped to sources when external `source-map` is used