### PR TITLE
fix: print stats only on warnings/errors

### DIFF
--- a/src/run-tests.ts
+++ b/src/run-tests.ts
@@ -39,10 +39,7 @@ export async function runTests(testFiles: string[], options: IRunTestsOptions = 
         units: testFiles,
       },
       plugins: createPluginsConfig(webpackConfig.plugins, options),
-      infrastructureLogging: {
-        level: 'warn',
-        ...webpackConfig.infrastructureLogging,
-      },
+      stats: 'errors-warnings',
     });
 
     const devMiddleware = webpackDevMiddleware(compiler);


### PR DESCRIPTION
infrastructureLogging used to affect the way dev-middleware prints the stats. this is no longer the case, starting with webpack-dev-middleware@4.0.3.